### PR TITLE
Make QSSTV file system permissions more sandboxed

### DIFF
--- a/net.qsl.QSSTV.yml
+++ b/net.qsl.QSSTV.yml
@@ -9,7 +9,7 @@ finish-args:
   - --device=all
   - --socket=pulseaudio
   - --share=network
-  - --filesystem=home
+  - --persist=qsstv
 cleanup:
   - /man
   - /include


### PR DESCRIPTION
There is no point in QSSTV having full home file system access anymore; making the qsstv directory persistent inside a sandbox is sufficient. Adding new pictures can be done without full access to home thanks to the XDG desktop portal. The only downside of this change is that it sadly breaks saved settings and other data for existing users, but it will be redeemed by the benefits of this change + it is better to change this sooner than later.